### PR TITLE
added-math-lib-linker-flag

### DIFF
--- a/sqlite3_opt_sqleanall.go
+++ b/sqlite3_opt_sqleanall.go
@@ -9,5 +9,6 @@ package sqlite3
 
 /*
 #cgo CFLAGS: -DSQLITE_ENABLE_SQLEANALL -DSQLITE_ENABLE_UNICODE
+#cgo LDFLAGS: -lm
 */
 import "C"


### PR DESCRIPTION
## Summary:

  - Added `-lm` linker flag for math lib.
  - Corrects `linux` build errors.